### PR TITLE
Use RTL friendly styling directives for close button

### DIFF
--- a/styles/minimal-dark.css
+++ b/styles/minimal-dark.css
@@ -65,7 +65,7 @@
 
 .geoapify-close-button {
     position: absolute;
-    right: 5px;
+    inset-inline-end: 5px;
     top: 0;
 
     height: 100%;

--- a/styles/minimal-dark.css
+++ b/styles/minimal-dark.css
@@ -74,7 +74,7 @@
 }
 
 .geoapify-close-button.visible {
-    display: flex;
+    display: inline-flex;
 }
 
 .geoapify-close-button {

--- a/styles/minimal.css
+++ b/styles/minimal.css
@@ -66,7 +66,7 @@
 }
 
 .geoapify-close-button.visible {
-    display: flex;
+    display: inline-flex;
 }
 
 .geoapify-close-button {

--- a/styles/minimal.css
+++ b/styles/minimal.css
@@ -57,7 +57,7 @@
 
 .geoapify-close-button {
     position: absolute;
-    right: 5px;
+    inset-inline-end: 5px;
     top: 0;
 
     height: 100%;

--- a/styles/round-borders-dark.css
+++ b/styles/round-borders-dark.css
@@ -79,7 +79,7 @@
 }
 
 .geoapify-close-button.visible {
-    display: flex;
+    display: inline-flex;
 }
 
 .geoapify-close-button {

--- a/styles/round-borders.css
+++ b/styles/round-borders.css
@@ -60,7 +60,7 @@
 
 .geoapify-close-button {
     position: absolute;
-    right: 5px;
+    inset-inline-end: 5px;
     top: 0;
 
     height: 100%;

--- a/styles/round-borders.css
+++ b/styles/round-borders.css
@@ -69,7 +69,7 @@
 }
 
 .geoapify-close-button.visible {
-    display: flex;
+    display: inline-flex;
 }
 
 .geoapify-close-button {


### PR DESCRIPTION
Hi everyone. First of all, thanks for making this. I'm using this for [a project I'm working on](https://testing.hazardready.org/seattle) and it's working great for the most part. 

I just had to make a patch in my own CSS to override something that didn't work with the RTL version of my site. In Arabic, the close button for the address autocomplete appears on top of the user's input text, like this:

![image](https://github.com/geoapify/geocoder-autocomplete/assets/547883/19e12096-a4ff-4f46-a19a-1e4473254c0a)

The patch I made moves the close button over to the left, for RTL languages.

This pull request would apply that patch to your repo, if you are interested in using it. It uses logical properties to position the close button, instead of `right`, according to these guidelines: https://rtlstyling.com/posts/rtl-styling#logical-properties-cheat-sheet


