### PR TITLE
fix: resolve commonjs module bundling in rollup config

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@geoapify/geocoder-autocomplete",
   "version": "2.0.2",
   "description": "Postal address autocomplete input field",
-  "main": "dist/index.js",
+  "main": "dist/index.cjs.js",
   "typings": "dist/index.d.ts",
   "minimized": "dist/index.min.js",
   "module": "dist/index.min.esm.js",

--- a/rollup-config.mjs
+++ b/rollup-config.mjs
@@ -30,7 +30,13 @@ export default [{
       format: 'esm',
       sourcemap: true,
 			freeze: false
-    }
+    },
+    {
+      file: pkg.main,
+      format: 'cjs',
+      sourcemap: true,
+      freeze: false
+    },
   ],
   plugins: [
     json(),


### PR DESCRIPTION
Resolve https://github.com/geoapify/geocoder-autocomplete/issues/6 through introducing commonjs module bundling